### PR TITLE
Change url for virtual assistant to use http instead of https

### DIFF
--- a/Access API/Access API/Urls.cs
+++ b/Access API/Access API/Urls.cs
@@ -9,6 +9,6 @@ namespace Access_API
     {
         public static string fileTransferUrl = "http://knox-master01.srv.aau.dk/fileAPI";
         public static string searchUrl = "http://knox-master01.srv.aau.dk/searchAPI";
-        public static string vaUrl = "https://knox-master01.srv.aau.dk/virtualAssistantAPI";
+        public static string vaUrl = "http://knox-master01.srv.aau.dk/virtualAssistantAPI";
     }
 }


### PR DESCRIPTION
We unfortunately used the https url for the API, which creates a lot of problem when trying to deploy our API on the server 
